### PR TITLE
Fix apollo errors, use event emitter

### DIFF
--- a/src/hooks/useApolloClient.ts
+++ b/src/hooks/useApolloClient.ts
@@ -10,6 +10,7 @@ import {
 import { setContext } from '@apollo/client/link/context';
 import { onError } from '@apollo/client/link/error';
 import fetch from 'cross-fetch';
+import { EventRegister } from 'react-native-event-listeners';
 import { v4 as uuidv4 } from 'uuid';
 
 import { VariantApiConfig } from '../types/VariantChat';
@@ -36,17 +37,19 @@ export const useApolloClient = (
             message === 'Not authenticated'
           )
         ) {
-          console.error(
-            `GraphQL error: ${operation.operationName} - ${message}`
-          );
+          EventRegister.emit('error', {
+            type: 'internal',
+            message: `GraphQL error: ${operation.operationName} - ${message}`,
+          });
         }
       });
     }
 
     if (networkError) {
-      console.error(
-        `GraphQL network error: ${operation.operationName} - ${networkError.message}`
-      );
+      EventRegister.emit('error', {
+        type: 'internal',
+        message: `GraphQL network error: ${operation.operationName} - ${networkError.message}`,
+      });
     }
   });
 

--- a/src/lib/Freshchat/FreshchatConversation.ts
+++ b/src/lib/Freshchat/FreshchatConversation.ts
@@ -11,15 +11,20 @@ export async function getFreshchatConversations(
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const apolloClient = useApolloClient();
 
-  if (apolloClient) {
-    const { data } = await apolloClient.query<DriverConversationQueryResponse>({
-      query: GET_DRIVER_CONVERSATION,
-      variables: { driverId: currentDriverId },
-    });
+  try {
+    if (apolloClient) {
+      const { data } =
+        await apolloClient.query<DriverConversationQueryResponse>({
+          query: GET_DRIVER_CONVERSATION,
+          variables: { driverId: currentDriverId },
+        });
 
-    const conversations: FreshchatConversationResponse =
-      data?.driver?.conversations ?? null;
-    return conversations;
+      const conversations: FreshchatConversationResponse =
+        data?.driver?.conversations ?? null;
+      return conversations;
+    }
+  } catch {
+    // Error emitted by ApolloClient
   }
 
   return null;


### PR DESCRIPTION
Problem
=======
Apollo errors not being handled correctly leading to unhandled promise

Solution
========
Catch potential unhandled promise. Emit events rather than log errors.