### PR TITLE
Set message polling interval via LD flag

### DIFF
--- a/src/hooks/useFreshchat.ts
+++ b/src/hooks/useFreshchat.ts
@@ -4,7 +4,7 @@ import BackgroundTimer from 'react-native-background-timer';
 import { EventRegister } from 'react-native-event-listeners';
 import Tts from 'react-native-tts';
 import { useSelector } from 'react-redux';
-import { SECOND } from 'time-constants';
+import { MINUTE } from 'time-constants';
 import { v4 as uuidv4 } from 'uuid';
 
 import { FreshchatCommunicationError } from '../lib/Exception';
@@ -74,7 +74,7 @@ import { IOpsMessage } from '../types/Message.interface';
 import { ChatCapabilities, ChatProviderConfig } from '../types/VariantChat';
 
 let dispatch: any;
-const NEW_MESSAGES_POLL_INTERVAL = 30 * SECOND;
+const NEW_MESSAGES_POLL_INTERVAL = 15 * MINUTE;
 
 export const useConsumerDispatch = (): any => {
   return dispatch;
@@ -452,7 +452,7 @@ export const useFreshchatGetMoreMessages = (
 };
 
 export const useFreshchatGetNewMessages = (
-  capabilities: ChatCapabilities,
+  capabilities: ChatCapabilities
 ): (() => void) => {
   const conversationInfo = useSelector(selectFreshchatConversationInfo);
   const conversationUsers = useSelector(selectFreshchatConversationUsers);
@@ -461,7 +461,11 @@ export const useFreshchatGetNewMessages = (
   const driverStatus = useSelector(selectDriverStatus);
   const appState = useRef(AppState.currentState);
   const lastBackgroundMessage = useRef<string | null>(null);
-  const pollingInterval = capabilities?.messagePolling[driverStatus] || NEW_MESSAGES_POLL_INTERVAL;
+
+  let pollingInterval = NEW_MESSAGES_POLL_INTERVAL;
+  if (driverStatus && capabilities?.messagePolling[driverStatus]) {
+    pollingInterval = capabilities?.messagePolling[driverStatus];
+  }
 
   useEffect(() => {
     AppState.addEventListener('change', handleAppStateChange);

--- a/src/hooks/useFreshchat.ts
+++ b/src/hooks/useFreshchat.ts
@@ -452,7 +452,7 @@ export const useFreshchatGetMoreMessages = (
 };
 
 export const useFreshchatGetNewMessages = (
-  capabilities: ChatCapabilities
+  capabilities: ChatCapabilities | undefined
 ): (() => void) => {
   const conversationInfo = useSelector(selectFreshchatConversationInfo);
   const conversationUsers = useSelector(selectFreshchatConversationUsers);

--- a/src/index.js
+++ b/src/index.js
@@ -30,13 +30,13 @@ export { EventRegister as VariantChatEvent };
 export { VariantChatEventType };
 
 /**
-
-* Provides Variant chat the driver status.
+ * Provides Variant chat the driver status.
  */
 export { DriverStatus };
 export { setDriverStatus } from './lib/VariantChat';
 
-/* Provides ability to reset internal state.
+/**
+ * Provides ability to reset internal state.
  */
 export { resetVariantChat } from './hooks/useFreshchat';
 

--- a/src/lib/VariantChat.ts
+++ b/src/lib/VariantChat.ts
@@ -19,9 +19,7 @@ export const useConsumerDispatch = (): any => {
   return dispatch;
 };
 
-let getNewMessages = (): void => {
-  return;
-};
+let getNewMessages = () => {};
 
 const useVariantChat = (
   driverId: string,
@@ -31,7 +29,7 @@ const useVariantChat = (
   dispatch = consumerDispatch;
   useApolloClient(config.variantApi);
   useFreshchatInit(driverId, config.chatProvider, dispatch);
-  getNewMessages = useFreshchatGetNewMessages();
+  getNewMessages = useFreshchatGetNewMessages(config.capabilities);
 };
 
 const handlePushNotification = (

--- a/src/lib/VariantChat.ts
+++ b/src/lib/VariantChat.ts
@@ -19,7 +19,9 @@ export const useConsumerDispatch = (): any => {
   return dispatch;
 };
 
-let getNewMessages = () => {};
+let getNewMessages = (): void => {
+  return;
+};
 
 const useVariantChat = (
   driverId: string,

--- a/src/types/DriverStatus.ts
+++ b/src/types/DriverStatus.ts
@@ -1,7 +1,7 @@
 export enum DriverStatus {
   Unknown = 'Unknown',
   Driving = 'Driving',
-  OnDuty = 'On Duty',
-  OffDuty = 'Off Duty',
-  SleeperBerth = 'Sleeper Berth',
+  OnDuty = 'OnDuty',
+  OffDuty = 'OffDuty',
+  SleeperBerth = 'SleeperBerth',
 }

--- a/src/types/VariantChat.d.ts
+++ b/src/types/VariantChat.d.ts
@@ -13,9 +13,19 @@ export interface VariantApiConfig {
   url: string;
 }
 
+export interface ChatCapabilities {
+  messagePolling: {
+    Driving: number;
+    OnDuty: number;
+    OffDuty: number;
+    SleeperBerth: number;
+  }
+}
+
 export interface VariantChatConfig {
   chatProvider: ChatProviderConfig;
   variantApi: VariantApiConfig;
+  capabilities?: ChatCapabilities;
 }
 
 export interface VariantChatProps {

--- a/src/types/VariantChat.d.ts
+++ b/src/types/VariantChat.d.ts
@@ -19,7 +19,8 @@ export interface ChatCapabilities {
     OnDuty: number;
     OffDuty: number;
     SleeperBerth: number;
-  }
+    Unknown: number;
+  };
 }
 
 export interface VariantChatConfig {


### PR DESCRIPTION
Add ability to set message polling interval via a launch darkly flag. If no flag is set then a built-in default value is used.