### PR TITLE
Update no conversation type, remove commented lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ The following events are emitted from the library. Your app should register for 
 
 Event name | Description | Types | Data
 ------ | ------ | ------ | ------
-**`error`** | Variant chat has encountered an error | `conversation`, `internal`, `service` | {message: String}
+**`error`** | Variant chat has encountered an error | `no-conversation`, `internal`, `service` | {message: String}
 **`messageReceived`** | Variant chat has received a chat message from the provider, message received while the app is in the background | `background` | {channelName: String, message: String}
 **`unreadMessageCounts`** | For each channel, the number of unread messages | `unreadMessageCounts` | {'channel-name': Number, ...} e.g. channel-name may be 'Chat with Team'.
 

--- a/src/hooks/useFreshchat.ts
+++ b/src/hooks/useFreshchat.ts
@@ -214,7 +214,6 @@ export const useFreshchatInit = (
           });
       }
 
-      // setInitialized(FreshchatInit.Success);
       initializedRef.current = FreshchatInit.Success;
     }
 
@@ -222,11 +221,10 @@ export const useFreshchatInit = (
   };
 
   const conversationError = (message: string) => {
-    // setInitialized(FreshchatInit.Fail);
     initializedRef.current = FreshchatInit.Fail;
 
     EventRegister.emit('error', {
-      type: 'conversation',
+      type: 'no-conversation',
       data: {
         message: `Conversation error: ${message}`,
       },
@@ -234,7 +232,6 @@ export const useFreshchatInit = (
   };
 
   const serviceError = (message: string) => {
-    // setInitialized(FreshchatInit.Fail);
     initializedRef.current = FreshchatInit.Fail;
 
     EventRegister.emit('error', {
@@ -251,14 +248,12 @@ export const useFreshchatInit = (
         initializedRef.current !== FreshchatInit.Success &&
         initializedRef.current !== FreshchatInit.InProgress
       ) {
-        // setInitialized(FreshchatInit.InProgress);
         initializedRef.current = FreshchatInit.InProgress;
 
         init(config);
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
-      // setInitialized(FreshchatInit.Fail);
       initializedRef.current = FreshchatInit.Fail;
 
       if (error instanceof FreshchatCommunicationError) {
@@ -273,7 +268,6 @@ export const useFreshchatInit = (
     }
 
     return () => {
-      // setInitialized(FreshchatInit.None);
       initializedRef.current = FreshchatInit.None;
     };
   }, [driverId]);


### PR DESCRIPTION
Problem
=======
The boolean target for when no conversation exists is too abstract.

Solution
========
Rename the event target type name.