### PR TITLE
RGR-677 Add event to signal successful chat initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Event name | Description | Types | Data
 ------ | ------ | ------ | ------
 **`EventName.Info`** | Variant chat informational event | `EventMessageType.Performance` | {message: String}
 **`EventName.Error`** | Variant chat has encountered an error | `EventMessageType.NoDriver`, `EventMessageType.NoConversation`, `EventMessageType.Internal`, `EventMessageType.Service` | {message: String}
+**`EventName.Initialized`** | Variant chat has successfully initialized | `EventMessageType.Internal` | {channelNames: String[]}
 **`EventName.MessageReceived`** | Variant chat has received a chat message from the provider, message received while the app is in the background | `EventMessageType.Background` | {channelName: String, message: String}
 **`EventName.UnreadMessageCounts`** | For each channel, the number of unread messages | `EventMessageType.UnreadMessageCounts` | {'channel-name': Number, ...} e.g. channel-name may be 'Chat with Team'.
 

--- a/src/hooks/useFreshchat.ts
+++ b/src/hooks/useFreshchat.ts
@@ -124,15 +124,6 @@ export const useFreshchatInit = (
         conversationInfo = await getFreshchatConversations(driverId);
         if (conversationInfo?.conversations) {
           await dispatch(freshchatSetConversationInfo({ conversationInfo }));
-
-          EventRegister.emit(EventName.Debug, {
-            type: EventMessageType.Log,
-            data: {
-              message: `Conversations available for driver: ${JSON.stringify(
-                conversationInfo
-              )})`,
-            },
-          });
         } else if (conversationInfo?.statusCode === 404) {
           driverError(`${conversationInfo?.message} (driver ${driverId})`);
           return;
@@ -225,11 +216,21 @@ export const useFreshchatInit = (
 
       // reports current unread messages' count
       reportCurrentFreshchatUnreadMessageCounts();
+      reportInitializationComplete(conversationInfo);
 
       initializedRef.current = FreshchatInit.Success;
     }
 
     Tts.getInitStatus();
+  };
+
+  const reportInitializationComplete = (conversationInfo: FreshchatConversationInfo) => {
+    EventRegister.emit(EventName.Initialized, {
+      type: EventMessageType.Internal,
+      data: {
+        conversationInfo,
+      },
+    });
   };
 
   const driverError = (message: string) => {

--- a/src/hooks/useFreshchat.ts
+++ b/src/hooks/useFreshchat.ts
@@ -224,11 +224,15 @@ export const useFreshchatInit = (
     Tts.getInitStatus();
   };
 
-  const reportInitializationComplete = (conversationInfo: FreshchatConversationInfo) => {
+  const reportInitializationComplete = (
+    conversationInfo: FreshchatConversationInfo
+  ) => {
     EventRegister.emit(EventName.Initialized, {
       type: EventMessageType.Internal,
       data: {
-        conversationInfo,
+        channelNames: conversationInfo?.conversations.map((c) => {
+          return c.channel;
+        }),
       },
     });
   };

--- a/src/types/EventName.enum.ts
+++ b/src/types/EventName.enum.ts
@@ -2,6 +2,7 @@ export enum EventName {
   Info = 'info',
   Debug = 'debug',
   Error = 'error',
+  Initialized = 'initialized',
   MessageReceived = 'messageReceived',
   UnreadMessageCounts = 'unreadMessageCounts',
 }


### PR DESCRIPTION
Problem
=======
The consuming app has no insight into when the chat component has loaded successfully. Knowing this is useful for UI interaction in the consuming app.
[link to JIRA RGR-677](https://usxtech.atlassian.net/browse/RGR-677)

Solution
========
Added an event to signal successful intialization. Event passes conversation data to the host app.
