### PR TITLE
RGR-623 Fix/updates for video and image messages

### DIFF
--- a/src/components/Bubble.tsx
+++ b/src/components/Bubble.tsx
@@ -166,14 +166,16 @@ const CustomBubble = (
         messagePart.file.content_type.toLowerCase().includes('image')
       ) {
         // image (attachment)
-        item.text = messagePart.file.name;
+        // we don't feel the need to show image file name
+        // item.text = messagePart.file.name;
         item.image = messagePart.file.url;
       } else if (
         messagePart.file &&
         messagePart.file.content_type.toLowerCase().includes('video')
       ) {
         // video (attachment)
-        item.text = messagePart.file.name;
+        // we don't feel the need to show video file name
+        // item.text = messagePart.file.name;
         item.video = messagePart.file.url;
       } else if (
         messagePart.file &&
@@ -333,6 +335,17 @@ const CustomBubble = (
       currentMessage: {
         ...messageImageProps.currentMessage,
         image: message.image,
+      },
+      containerStyle: {
+        padding: 8,
+        width: 250,
+        minHeight: 100,
+        maxWidth: '100%',
+      },
+      imageStyle: {
+        width: '100%',
+        margin: 0,
+        resizeMode: 'contain',
       },
     };
 

--- a/src/components/MessageVideo.tsx
+++ b/src/components/MessageVideo.tsx
@@ -1,9 +1,15 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useTheme } from 'react-native-paper';
+import { ActivityIndicator, useTheme } from 'react-native-paper';
 import Video from 'react-native-video';
 
 import { IOpsVideoMessage } from '../types/VideoMessage.interface';
+
+enum VideoStatus {
+  NONE = 'NONE',
+  LOADING = 'LOADING',
+  LOADED = 'LOADED',
+}
 
 const CustomMessageVideo = (props: IOpsVideoMessage): ReactElement => {
   const {
@@ -15,6 +21,8 @@ const CustomMessageVideo = (props: IOpsVideoMessage): ReactElement => {
 
   const theme = useTheme();
   const styles = localStyleSheet(theme);
+  const [status, setStatus] = useState(VideoStatus.NONE);
+  const isLoading = status === VideoStatus.LOADING;
 
   return (
     <View style={[styles.container, containerStyle]}>
@@ -23,13 +31,17 @@ const CustomMessageVideo = (props: IOpsVideoMessage): ReactElement => {
         source={{ uri: props.currentMessage?.video }}
         controls
         paused
-        onFullscreenPlayerDidPresent={() =>
-          onDidPresentFullscreen && onDidPresentFullscreen()
-        }
-        onFullscreenPlayerDidDismiss={() =>
-          onDidDismissFullscreen && onDidDismissFullscreen()
-        }
+        resizeMode="contain"
+        onFullscreenPlayerDidPresent={onDidPresentFullscreen}
+        onFullscreenPlayerDidDismiss={onDidDismissFullscreen}
+        onLoadStart={() => setStatus(VideoStatus.LOADING)}
+        onLoad={() => setStatus(VideoStatus.LOADED)}
       />
+      {isLoading && (
+        <View style={styles.loadingSpinner}>
+          <ActivityIndicator animating color={theme.colors.primary} />
+        </View>
+      )}
     </View>
   );
 };
@@ -37,16 +49,26 @@ const CustomMessageVideo = (props: IOpsVideoMessage): ReactElement => {
 function localStyleSheet(theme: ReactNativePaper.Theme) {
   return StyleSheet.create({
     container: {
-      height: 150,
       width: 250,
-      marginLeft: 12,
-      paddingHorizontal: 15,
+      height: 150,
+      maxWidth: '100%',
+      padding: 8,
       alignSelf: 'center',
     },
+    loadingSpinner: {
+      position: 'absolute',
+      top: 8,
+      left: 8,
+      right: 8,
+      bottom: 8,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
     video: {
-      height: 150,
+      width: '100%',
+      height: '100%',
       backgroundColor: theme.colors.common.black,
-      borderRadius: 12,
+      borderRadius: 10,
     },
   });
 }


### PR DESCRIPTION
This does:
- Show loading spinner while loading first play data of video message.
- Change video resize mode to 'contain'.
- Change image resize mode to 'contain' so users can see the whole image regardless of scale.
- Get rid of video and image file names on message bubbles.
- Fix padding issue on video/image frame.

Problem
=======
problem statement, including
[RGR-623](https://usxtech.atlassian.net/browse/RGR-623)

Solution
========
What I/we did to solve this problem
with @pairperson1

Screenshots (optional):
-----------------------
Screenshot of Android device

https://user-images.githubusercontent.com/80545423/150219628-d48d31cc-0955-40eb-a42d-afdb3c902303.mp4


