### PR TITLE
PDF bubble content alignment, remove filename

### DIFF
--- a/src/components/Bubble.tsx
+++ b/src/components/Bubble.tsx
@@ -182,7 +182,8 @@ const CustomBubble = (
         messagePart.file.content_type.toLowerCase().includes('pdf')
       ) {
         // pdf document (attachment)
-        item.text = messagePart.file.name;
+        // we don't feel the need to show pdf file name
+        // item.text = messagePart.file.name;
         item.pdf = messagePart.file.url;
       }
 

--- a/src/components/MessagePdf.tsx
+++ b/src/components/MessagePdf.tsx
@@ -54,12 +54,15 @@ MessagePdf.defaultProps = {
 
 function localStyleSheet(theme: ReactNativePaper.Theme) {
   return StyleSheet.create({
-    container: {},
+    container: {
+      padding: 8,
+      minHeight: 100,
+      alignItems: 'center',
+},
     pdf: {
       width: 150,
       height: 100,
       borderRadius: 13,
-      margin: 3,
       backgroundColor: theme.colors.chat.bubbleReceive,
     },
     pdfActive: {


### PR DESCRIPTION
Problem
=======
PDF image in bubble is shifted right , extends outside bubble.
PDF bubble shows filename.

Solution
========
Fix PDF image alignment.
Remove PDF filename.
