### PR TITLE
RDP-9 Roger chat: unencoded non-ascii glyphs crashes the Roger App

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6333,6 +6333,11 @@
         "whatwg-encoding": "^1.0.5"
       }
     },
+    "html-entities": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "axios": "^0.21.1",
     "base64-arraybuffer": "^1.0.2",
     "cross-fetch": "^3.0.6",
+    "html-entities": "^2.3.2",
     "react": "^17.0.2",
     "react-native": "^0.64.0",
     "react-native-actionsheet": "^2.4.2",

--- a/src/components/Bubble.tsx
+++ b/src/components/Bubble.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { decode } from 'html-entities';
 import React from 'react';
 import {
   StyleProp,
@@ -158,7 +159,7 @@ const CustomBubble = (
         }
 
         item.urgent = urgent;
-        item.text = messageText;
+        item.text = decode(messageText);
 
         const filename = messageText.split('/').pop();
         const mimeType = mime.lookup(filename);


### PR DESCRIPTION
Problem
=======
- Roger chat: unencoded non-ascii glyphs crashes the Roger App

[link to JIRA RDP-9](https://usxtech.atlassian.net/browse/RDP-9)

Solution
========
- Decodes html special characters
For instance: `&amp;` => `&`

Screenshots (optional):
-----------------------
Screenshot of Android device
