### PR TITLE
Add error detection for an invalid PS token

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ The following events are emitted from the library. Your app should register for 
 Event name | Description | Types | Data
 ------ | ------ | ------ | ------
 **`EventName.Info`** | Variant chat informational event | `EventMessageType.Performance` | {message: String}
-**`EventName.Error`** | Variant chat has encountered an error | `EventMessageType.NoDriver`, `EventMessageType.NoConversation`, `EventMessageType.Internal`, `EventMessageType.Service` | {message: String}
+**`EventName.Error`** | Variant chat has encountered an error | `EventMessageType.NotAuthenticated`, `EventMessageType.NoDriver`, `EventMessageType.NoConversation`, `EventMessageType.Internal`, `EventMessageType.Service` | {message: String}
 **`EventName.Initialized`** | Variant chat has successfully initialized | `EventMessageType.Internal` | {channelNames: String[]}
 **`EventName.MessageReceived`** | Variant chat has received a chat message from the provider, message received while the app is in the background | `EventMessageType.Background` | {channelName: String, message: String}
 **`EventName.UnreadMessageCounts`** | For each channel, the number of unread messages | `EventMessageType.UnreadMessageCounts` | {'channel-name': Number, ...} e.g. channel-name may be 'Chat with Team'.

--- a/src/types/EventMessageType.enum.ts
+++ b/src/types/EventMessageType.enum.ts
@@ -7,4 +7,5 @@ export enum EventMessageType {
   NoDriver = 'no-driver',
   Background = 'background',
   UnreadMessageCounts = 'unreadMessageCounts',
+  NotAuthenticated = 'not-authenticated',
 }


### PR DESCRIPTION
Problem
=======
No discreet detection of invalid PS auth token

Solution
========
Detect an auth failure at shift and provide an error route